### PR TITLE
Temporary fix for the eventloop leak.

### DIFF
--- a/rl-nf-edge-tier/src/main/java/io/reactivex/lab/edge/nf/clients/AbstractHystrixCommand.java
+++ b/rl-nf-edge-tier/src/main/java/io/reactivex/lab/edge/nf/clients/AbstractHystrixCommand.java
@@ -1,0 +1,32 @@
+package io.reactivex.lab.edge.nf.clients;
+
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixObservableCommand;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.reactivex.netty.client.RxClientThreadFactory;
+import io.reactivex.netty.pipeline.PipelineConfigurators;
+import io.reactivex.netty.protocol.http.client.HttpClient;
+import io.reactivex.netty.protocol.http.client.HttpClientBuilder;
+import io.reactivex.netty.protocol.text.sse.ServerSentEvent;
+
+/**
+ * @author Nitesh Kant
+ */
+abstract class AbstractHystrixCommand<T> extends HystrixObservableCommand<T> {
+
+    private static final EventLoopGroup
+            clientGroup = new NioEventLoopGroup(0 /*means default in netty*/, new RxClientThreadFactory());
+
+    protected AbstractHystrixCommand(HystrixCommandGroupKey group) {
+        super(group);
+    }
+
+    protected static HttpClient<ByteBuf, ServerSentEvent> newClient(String host, int port) {
+        return new HttpClientBuilder<ByteBuf, ServerSentEvent>(host, port)
+                .pipelineConfigurator(PipelineConfigurators.<ByteBuf>sseClientConfigurator())
+                .eventloop(clientGroup)
+                .build();
+    }
+}

--- a/rl-nf-edge-tier/src/main/java/io/reactivex/lab/edge/nf/clients/BookmarksCommand.java
+++ b/rl-nf-edge-tier/src/main/java/io/reactivex/lab/edge/nf/clients/BookmarksCommand.java
@@ -1,23 +1,17 @@
 package io.reactivex.lab.edge.nf.clients;
 
-import io.netty.buffer.ByteBuf;
+import com.netflix.hystrix.HystrixCommandGroupKey;
 import io.reactivex.lab.edge.common.SimpleJson;
 import io.reactivex.lab.edge.nf.clients.BookmarksCommand.Bookmark;
 import io.reactivex.lab.edge.nf.clients.PersonalizedCatalogCommand.Video;
-import io.reactivex.netty.RxNetty;
-import io.reactivex.netty.pipeline.PipelineConfigurators;
 import io.reactivex.netty.protocol.http.client.HttpClientRequest;
+import rx.Observable;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import rx.Observable;
-
-import com.netflix.hystrix.HystrixCommandGroupKey;
-import com.netflix.hystrix.HystrixObservableCommand;
-
-public class BookmarksCommand extends HystrixObservableCommand<Bookmark> {
+public class BookmarksCommand extends AbstractHystrixCommand<Bookmark> {
 
     final List<Video> videos;
 
@@ -33,7 +27,7 @@ public class BookmarksCommand extends HystrixObservableCommand<Bookmark> {
 
     @Override
     protected Observable<Bookmark> run() {
-        return RxNetty.createHttpClient("localhost", 9190, PipelineConfigurators.<ByteBuf> sseClientConfigurator())
+        return newClient("localhost", 9190)
                 .submit(HttpClientRequest.createGet("/bookmarks?" + UrlGenerator.generate("videoId", videos)))
                 .flatMap(r -> {
                     Observable<Bookmark> bytesToJson = r.getContent().map(sse -> {

--- a/rl-nf-edge-tier/src/main/java/io/reactivex/lab/edge/nf/clients/GeoCommand.java
+++ b/rl-nf-edge-tier/src/main/java/io/reactivex/lab/edge/nf/clients/GeoCommand.java
@@ -1,22 +1,15 @@
 package io.reactivex.lab.edge.nf.clients;
 
-import io.netty.buffer.ByteBuf;
+import com.netflix.hystrix.HystrixCommandGroupKey;
 import io.reactivex.lab.edge.common.SimpleJson;
 import io.reactivex.lab.edge.nf.clients.GeoCommand.GeoIP;
-import io.reactivex.netty.RxNetty;
-import io.reactivex.netty.pipeline.PipelineConfigurators;
 import io.reactivex.netty.protocol.http.client.HttpClientRequest;
-import io.reactivex.netty.protocol.http.client.HttpClientResponse;
+import rx.Observable;
 
 import java.util.List;
 import java.util.Map;
 
-import rx.Observable;
-
-import com.netflix.hystrix.HystrixCommandGroupKey;
-import com.netflix.hystrix.HystrixObservableCommand;
-
-public class GeoCommand extends HystrixObservableCommand<GeoIP> {
+public class GeoCommand extends AbstractHystrixCommand<GeoIP> {
 
     private final List<String> ips;
 
@@ -27,7 +20,7 @@ public class GeoCommand extends HystrixObservableCommand<GeoIP> {
 
     @Override
     protected Observable<GeoIP> run() {
-        return RxNetty.createHttpClient("localhost", 9191, PipelineConfigurators.<ByteBuf> sseClientConfigurator())
+        return newClient("localhost", 9191)
                 .submit(HttpClientRequest.createGet("/geo?" + UrlGenerator.generate("ip", ips)))
                 .flatMap(r -> {
                     Observable<GeoIP> bytesToJson = r.getContent().map(sse -> {

--- a/rl-nf-edge-tier/src/main/java/io/reactivex/lab/edge/nf/clients/PersonalizedCatalogCommand.java
+++ b/rl-nf-edge-tier/src/main/java/io/reactivex/lab/edge/nf/clients/PersonalizedCatalogCommand.java
@@ -1,23 +1,17 @@
 package io.reactivex.lab.edge.nf.clients;
 
-import io.netty.buffer.ByteBuf;
+import com.netflix.hystrix.HystrixCommandGroupKey;
 import io.reactivex.lab.edge.common.SimpleJson;
 import io.reactivex.lab.edge.nf.clients.PersonalizedCatalogCommand.Catalog;
 import io.reactivex.lab.edge.nf.clients.UserCommand.User;
-import io.reactivex.netty.RxNetty;
-import io.reactivex.netty.pipeline.PipelineConfigurators;
 import io.reactivex.netty.protocol.http.client.HttpClientRequest;
+import rx.Observable;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import rx.Observable;
-
-import com.netflix.hystrix.HystrixCommandGroupKey;
-import com.netflix.hystrix.HystrixObservableCommand;
-
-public class PersonalizedCatalogCommand extends HystrixObservableCommand<Catalog> {
+public class PersonalizedCatalogCommand extends AbstractHystrixCommand<Catalog> {
 
     private final List<User> users;
 
@@ -33,7 +27,7 @@ public class PersonalizedCatalogCommand extends HystrixObservableCommand<Catalog
 
     @Override
     protected Observable<Catalog> run() {
-        return RxNetty.createHttpClient("localhost", 9192, PipelineConfigurators.<ByteBuf> sseClientConfigurator())
+        return newClient("localhost", 9192)
                 .submit(HttpClientRequest.createGet("/catalog?" + UrlGenerator.generate("userId", users)))
                 .flatMap(r -> {
                     Observable<Catalog> bytesToJson = r.getContent().map(sse -> {

--- a/rl-nf-edge-tier/src/main/java/io/reactivex/lab/edge/nf/clients/RatingsCommand.java
+++ b/rl-nf-edge-tier/src/main/java/io/reactivex/lab/edge/nf/clients/RatingsCommand.java
@@ -1,23 +1,17 @@
 package io.reactivex.lab.edge.nf.clients;
 
-import io.netty.buffer.ByteBuf;
+import com.netflix.hystrix.HystrixCommandGroupKey;
 import io.reactivex.lab.edge.common.SimpleJson;
 import io.reactivex.lab.edge.nf.clients.PersonalizedCatalogCommand.Video;
 import io.reactivex.lab.edge.nf.clients.RatingsCommand.Rating;
-import io.reactivex.netty.RxNetty;
-import io.reactivex.netty.pipeline.PipelineConfigurators;
 import io.reactivex.netty.protocol.http.client.HttpClientRequest;
+import rx.Observable;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import rx.Observable;
-
-import com.netflix.hystrix.HystrixCommandGroupKey;
-import com.netflix.hystrix.HystrixObservableCommand;
-
-public class RatingsCommand extends HystrixObservableCommand<Rating> {
+public class RatingsCommand extends AbstractHystrixCommand<Rating> {
     private final List<Video> videos;
 
     public RatingsCommand(Video video) {
@@ -32,7 +26,7 @@ public class RatingsCommand extends HystrixObservableCommand<Rating> {
 
     @Override
     protected Observable<Rating> run() {
-        return RxNetty.createHttpClient("localhost", 9193, PipelineConfigurators.<ByteBuf> sseClientConfigurator())
+        return newClient("localhost", 9193)
                 .submit(HttpClientRequest.createGet("/ratings?" + UrlGenerator.generate("videoId", videos)))
                 .flatMap(r -> {
                     Observable<Rating> bytesToJson = r.getContent().map(sse -> {

--- a/rl-nf-edge-tier/src/main/java/io/reactivex/lab/edge/nf/clients/SocialCommand.java
+++ b/rl-nf-edge-tier/src/main/java/io/reactivex/lab/edge/nf/clients/SocialCommand.java
@@ -1,24 +1,17 @@
 package io.reactivex.lab.edge.nf.clients;
 
-import io.netty.buffer.ByteBuf;
+import com.netflix.hystrix.HystrixCommandGroupKey;
 import io.reactivex.lab.edge.common.SimpleJson;
 import io.reactivex.lab.edge.nf.clients.SocialCommand.Social;
 import io.reactivex.lab.edge.nf.clients.UserCommand.User;
-import io.reactivex.netty.RxNetty;
-import io.reactivex.netty.pipeline.PipelineConfigurators;
 import io.reactivex.netty.protocol.http.client.HttpClientRequest;
-import io.reactivex.netty.protocol.http.client.HttpClientResponse;
+import rx.Observable;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import rx.Observable;
-
-import com.netflix.hystrix.HystrixCommandGroupKey;
-import com.netflix.hystrix.HystrixObservableCommand;
-
-public class SocialCommand extends HystrixObservableCommand<Social> {
+public class SocialCommand extends AbstractHystrixCommand<Social> {
 
     private final List<User> users;
 
@@ -34,7 +27,7 @@ public class SocialCommand extends HystrixObservableCommand<Social> {
 
     @Override
     protected Observable<Social> run() {
-        return RxNetty.createHttpClient("localhost", 9194, PipelineConfigurators.<ByteBuf> sseClientConfigurator())
+        return newClient("localhost", 9194)
                 .submit(HttpClientRequest.createGet("/social?" + UrlGenerator.generate("userId", users)))
                 .flatMap(r -> {
                     Observable<Social> bytesToJson = r.getContent().map(sse -> {

--- a/rl-nf-edge-tier/src/main/java/io/reactivex/lab/edge/nf/clients/UserCommand.java
+++ b/rl-nf-edge-tier/src/main/java/io/reactivex/lab/edge/nf/clients/UserCommand.java
@@ -1,21 +1,15 @@
 package io.reactivex.lab.edge.nf.clients;
 
-import io.netty.buffer.ByteBuf;
+import com.netflix.hystrix.HystrixCommandGroupKey;
 import io.reactivex.lab.edge.common.SimpleJson;
 import io.reactivex.lab.edge.nf.clients.UserCommand.User;
-import io.reactivex.netty.RxNetty;
-import io.reactivex.netty.pipeline.PipelineConfigurators;
 import io.reactivex.netty.protocol.http.client.HttpClientRequest;
+import rx.Observable;
 
 import java.util.List;
 import java.util.Map;
 
-import rx.Observable;
-
-import com.netflix.hystrix.HystrixCommandGroupKey;
-import com.netflix.hystrix.HystrixObservableCommand;
-
-public class UserCommand extends HystrixObservableCommand<User> {
+public class UserCommand extends AbstractHystrixCommand<User> {
 
     private final List<String> userIds;
 
@@ -26,7 +20,7 @@ public class UserCommand extends HystrixObservableCommand<User> {
 
     @Override
     protected Observable<User> run() {
-        return RxNetty.createHttpClient("localhost", 9195, PipelineConfigurators.<ByteBuf> sseClientConfigurator())
+        return newClient("localhost", 9195)
                 .submit(HttpClientRequest.createGet("/user?" + UrlGenerator.generate("userId", userIds)))
                 .flatMap(r -> {
                     Observable<User> user = r.getContent().map(sse -> {

--- a/rl-nf-edge-tier/src/main/java/io/reactivex/lab/edge/nf/clients/VideoMetadataCommand.java
+++ b/rl-nf-edge-tier/src/main/java/io/reactivex/lab/edge/nf/clients/VideoMetadataCommand.java
@@ -1,23 +1,17 @@
 package io.reactivex.lab.edge.nf.clients;
 
-import io.netty.buffer.ByteBuf;
+import com.netflix.hystrix.HystrixCommandGroupKey;
 import io.reactivex.lab.edge.common.SimpleJson;
 import io.reactivex.lab.edge.nf.clients.PersonalizedCatalogCommand.Video;
 import io.reactivex.lab.edge.nf.clients.VideoMetadataCommand.VideoMetadata;
-import io.reactivex.netty.RxNetty;
-import io.reactivex.netty.pipeline.PipelineConfigurators;
 import io.reactivex.netty.protocol.http.client.HttpClientRequest;
+import rx.Observable;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import rx.Observable;
-
-import com.netflix.hystrix.HystrixCommandGroupKey;
-import com.netflix.hystrix.HystrixObservableCommand;
-
-public class VideoMetadataCommand extends HystrixObservableCommand<VideoMetadata> {
+public class VideoMetadataCommand extends AbstractHystrixCommand<VideoMetadata> {
 
     private final List<Video> videos;
 
@@ -33,7 +27,7 @@ public class VideoMetadataCommand extends HystrixObservableCommand<VideoMetadata
 
     @Override
     protected Observable<VideoMetadata> run() {
-        return RxNetty.createHttpClient("localhost", 9196, PipelineConfigurators.<ByteBuf> sseClientConfigurator())
+        return newClient("localhost", 9196)
                 .submit(HttpClientRequest.createGet("/metadata?" + UrlGenerator.generate("videoId", videos)))
                 .flatMap(r -> {
                     Observable<VideoMetadata> bytesToJson = r.getContent().map(sse -> {


### PR DESCRIPTION
 RxNetty.createHttpClient() creates a new Http Client which creates a brand new eventloop.
 RxNetty provides a way to override the eventloop through the client builder. This temporary fix uses the builder directly and hence a common eventloop for all clients.

 After RxNetty's issue https://github.com/Netflix/RxNetty/issues/89 gets fixed we can use RxNetty.createHttpClient() again.

 Also, removed lambdas from EdgeServer, for some reason I do not understand, my java8 compiler does not like the types used in the lambdas.
