### PR TITLE
Fixing dependencies for tutorial & service discovery module.

### DIFF
--- a/reactive-lab-service-discovery/build.gradle
+++ b/reactive-lab-service-discovery/build.gradle
@@ -2,6 +2,10 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
+
+    compile 'io.reactivex:rxnetty:0.5.0-SNAPSHOT'
+    compile 'io.reactivex:rxjava:1.0.+'
+
     compile "com.netflix.eureka:eureka2-client-shaded:2.0.0-rc.2"
     compile('com.netflix.eureka:eureka2-write-server:2.0.0-rc.2')
 

--- a/reactive-lab-tutorial/build.gradle
+++ b/reactive-lab-tutorial/build.gradle
@@ -2,6 +2,10 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
+
+    compile 'io.reactivex:rxnetty:0.5.0-SNAPSHOT'
+    compile 'io.reactivex:rxjava:1.0.+'
+
     compile "com.netflix.eureka:eureka2-client-shaded:2.0.0-rc.2"
     compile "com.netflix.ocelli:ocelli-rxnetty:0.2.0-SNAPSHOT"
     compile "com.netflix.ocelli:ocelli-eureka2:0.2.0-SNAPSHOT"


### PR DESCRIPTION
Those modules were not having direct dependencies on rxnetty & rxjava and hence were getting it transitively with a different version.